### PR TITLE
Zig 0.15.1

### DIFF
--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -4,22 +4,22 @@ when:
 
 steps:
     - name: Build and Test (race)
-      image: jcalabro/zoo-docs:2025-03-24
+      image: jcalabro/zu:2025-03-24
       commands: |
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Drace || true
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Drace
+          zig build --summary all -freference-trace -Drace || true
+          zig build --summary all -freference-trace -Drace
           ./zig-out/bin/zu
 
     - name: Build and Test (valgrind)
-      image: jcalabro/zoo-docs:2025-03-24
+      image: jcalabro/zu:2025-03-24
       commands: |
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe || true
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe
+          zig build --summary all -freference-trace -Doptimize=ReleaseSafe || true
+          zig build --summary all -freference-trace -Doptimize=ReleaseSafe
           valgrind --leak-check=full --error-exitcode=1 ./zig-out/bin/zu
 
     - name: Build and Test (release)
-      image: jcalabro/zoo-docs:2025-03-24
+      image: jcalabro/zu:2025-03-24
       commands: |
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe || true
-          zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe
+          zig build --summary all -freference-trace -Doptimize=ReleaseSafe || true
+          zig build --summary all -freference-trace -Doptimize=ReleaseSafe
           ./zig-out/bin/zu

--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -4,21 +4,21 @@ when:
 
 steps:
     - name: Build and Test (race)
-      image: jcalabro/zu:2025-03-24
+      image: jcalabro/zu:2025-08-30
       commands: |
           zig build --summary all -freference-trace -Drace || true
           zig build --summary all -freference-trace -Drace
           ./zig-out/bin/zu
 
     - name: Build and Test (valgrind)
-      image: jcalabro/zu:2025-03-24
+      image: jcalabro/zu:2025-08-30
       commands: |
           zig build --summary all -freference-trace -Doptimize=ReleaseSafe || true
           zig build --summary all -freference-trace -Doptimize=ReleaseSafe
           valgrind --leak-check=full --error-exitcode=1 ./zig-out/bin/zu
 
     - name: Build and Test (release)
-      image: jcalabro/zu:2025-03-24
+      image: jcalabro/zu:2025-08-30
       commands: |
           zig build --summary all -freference-trace -Doptimize=ReleaseSafe || true
           zig build --summary all -freference-trace -Doptimize=ReleaseSafe

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,5 @@ RUN dnf update -y && \
 
 RUN go install github.com/shivakar/quickserve@latest
 
-ADD zig_version.txt .
-RUN curl -L https://github.com/marler8997/zigup/releases/download/v2025_01_02/zigup-x86_64-linux.tar.gz | tar xz && \
-    mv zigup /usr/bin && \
-    zigup fetch $(cat zig_version.txt) && \
-    zigup default $(cat zig_version.txt) && rm zig_version.txt
+RUN curl -L https://github.com/marler8997/anyzig/releases/download/v2025_08_13/anyzig-x86_64-linux.tar.gz | tar xz && \
+    mv zig /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN dnf update -y && \
 RUN go install github.com/shivakar/quickserve@latest
 
 RUN curl -L https://github.com/marler8997/anyzig/releases/download/v2025_08_13/anyzig-x86_64-linux.tar.gz | tar xz && \
-    mv zig /usr/bin
+    mv zig /usr/bin && \
+    zig 0.15.1 --help # pull the version we use at image build time

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zu,
     .version = "0.0.1",
     .fingerprint = 0xb4660630dfa46fad,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     docs:
-        image: jcalabro/zoo-docs:2025-03-24
+        image: jcalabro/zu-docs:2025-03-24
         restart: always
         ports:
             - "8002:8080"

--- a/src/Error.zig
+++ b/src/Error.zig
@@ -43,14 +43,9 @@ pub fn set(
 }
 
 /// Formats the `Error` in to a string
-pub fn format(
-    self: Self,
-    comptime fmt: []const u8,
-    _: std.fmt.FormatOptions,
-    writer: anytype,
-) !void {
+pub fn format(self: @This(), writer: *std.io.Writer) !void {
     const msg = if (self.message) |m| m else "(none)";
-    _ = try writer.print("{" ++ fmt ++ "}", .{msg});
+    _ = try writer.print("{s}", .{msg});
 }
 
 /// Prints the error to stderr if an error is set, else is a noop. This is a convenience wrapper that's likely only appropriate for tests.
@@ -76,13 +71,13 @@ test "Error" {
     defer err.deinit();
 
     {
-        const msg = try std.fmt.allocPrint(t.allocator, "msg: {s}!", .{err});
+        const msg = try std.fmt.allocPrint(t.allocator, "msg: {f}!", .{err});
         defer t.allocator.free(msg);
         try t.expectEqualSlices(u8, "msg: (none)!", msg);
     }
 
     try err.set("hi", .{});
-    const msg = try std.fmt.allocPrint(t.allocator, "{s} there!", .{err});
+    const msg = try std.fmt.allocPrint(t.allocator, "{f} there!", .{err});
     defer t.allocator.free(msg);
     try t.expectEqualSlices(u8, "hi there!", msg);
 }

--- a/src/numeric.zig
+++ b/src/numeric.zig
@@ -100,16 +100,6 @@ pub fn Numeric(comptime T: type) type {
         pub fn jsonStringify(self: *const Self, jw: anytype) !void {
             try jw.write(self.int());
         }
-
-        /// Formats the `Numeric` in to a string as a primitive
-        pub fn format(
-            self: Self,
-            comptime fmt: []const u8,
-            _: std.fmt.FormatOptions,
-            writer: anytype,
-        ) !void {
-            _ = try writer.print("{" ++ fmt ++ "}", .{self.int()});
-        }
     };
 }
 
@@ -145,41 +135,15 @@ test "Numeric basic operations" {
 
 test "Numeric json operations" {
     const T = Numeric(u8);
-    const S = struct {
-        n: T,
-    };
+    const S = struct { n: T };
 
     const s = S{ .n = T.from(12) };
 
-    const json = try std.json.stringifyAlloc(t.allocator, s, .{});
+    const json = try std.json.Stringify.valueAlloc(t.allocator, s, .{});
     defer t.allocator.free(json);
     try t.expectEqualSlices(u8, "{\"n\":12}", json);
 
     const res = try std.json.parseFromSlice(S, t.allocator, json, .{});
     defer res.deinit();
     try t.expectEqual(s, res.value);
-}
-
-test "Numeric string formatting" {
-    const T = Numeric(i8);
-
-    {
-        // positive number
-        const n = T.from(12);
-        const decimal = try std.fmt.allocPrint(t.allocator, "val: {d}", .{n});
-        defer t.allocator.free(decimal);
-        try t.expectEqualSlices(u8, "val: 12", decimal);
-
-        const hex = try std.fmt.allocPrint(t.allocator, "val: 0x{x}", .{n});
-        defer t.allocator.free(hex);
-        try t.expectEqualSlices(u8, "val: 0xc", hex);
-    }
-
-    {
-        // negative number
-        const n = T.from(-12);
-        const decimal = try std.fmt.allocPrint(t.allocator, "val: {d}", .{n});
-        defer t.allocator.free(decimal);
-        try t.expectEqualSlices(u8, "val: -12", decimal);
-    }
 }

--- a/src/numeric.zig
+++ b/src/numeric.zig
@@ -100,6 +100,11 @@ pub fn Numeric(comptime T: type) type {
         pub fn jsonStringify(self: *const Self, jw: anytype) !void {
             try jw.write(self.int());
         }
+
+        /// Formats the `Numeric` in to a string as a primitive
+        pub fn format(self: Self, writer: *std.io.Writer) !void {
+            _ = try writer.print("{d}", .{self.int()});
+        }
     };
 }
 
@@ -146,4 +151,24 @@ test "Numeric json operations" {
     const res = try std.json.parseFromSlice(S, t.allocator, json, .{});
     defer res.deinit();
     try t.expectEqual(s, res.value);
+}
+
+test "Numeric string formatting" {
+    const T = Numeric(i8);
+
+    {
+        // positive number
+        const n = T.from(12);
+        const decimal = try std.fmt.allocPrint(t.allocator, "val: {f}", .{n});
+        defer t.allocator.free(decimal);
+        try t.expectEqualSlices(u8, "val: 12", decimal);
+    }
+
+    {
+        // negative number
+        const n = T.from(-12);
+        const decimal = try std.fmt.allocPrint(t.allocator, "val: {f}", .{n});
+        defer t.allocator.free(decimal);
+        try t.expectEqualSlices(u8, "val: -12", decimal);
+    }
 }


### PR DESCRIPTION
Only real behavior change is that numerics can no longer directly be formatted with `{x}`, `{d}`, etc. due to [writerage](https://github.com/ziglang/zig/pull/24329). Now, they can only be directly formatted as decimal with `{f}`, which is unfortunate. To use the old behavior, just get the underlying number with `int()` and format that.